### PR TITLE
Create Lays-Minecraft.json

### DIFF
--- a/eclipse/config/WailaNBT/Lays-Minecraft.json
+++ b/eclipse/config/WailaNBT/Lays-Minecraft.json
@@ -1,0 +1,281 @@
+{
+	".*" : {
+		".*(Lays-Minecraft)*" : {
+			"Age" : "function p(v){ if(v>=0){return '交配冷卻時間:\u00A7f' + Math.floor(v/20) +' 秒' }else{return '成長剩餘時間:\u00A7f' + Math.ceil(v/20)*(-1) +' 秒' }}"
+		},
+		"Skull" : {
+			"ExtraType" : "這是%s的頭顱!"
+		},"Cauldron":{
+		"BrewTime":"",
+			"Items>>>0>>>Damage":"function p(v){
+	//儲存所有藥水的資料
+	var potionArray=new function (){
+		//藥水的名稱
+		this.potionName=['','回覆','迅捷','抗火','劇毒','治療','夜視','清澈(不可能出現)','虛弱','力量','緩速','跳耀','傷害','水下呼吸','隱身','稀薄(不可能出現)'];
+		this.potionNarmalExtName=['水瓶','粗製的','混濁的','(延長版)平凡的','平凡的','<錯誤>'];
+		//藥水文字的顏色預設空字串
+		this.potionColor=['','','','','','','','','','','','','','','',''];
+		//藥水的種類，0為預設或是時效性藥水，1為時效性藥水(無藥水等級)
+		this.potionAttribute=[0,0,0,1,0,0,1,0,1,0,1,0,0,1,1,0];
+		//藥效的時長，若為藥效性藥水(立即治療)則值為0，單位為秒
+		this.potionEffectTime=[0,45,180,180,45,0,180,0,90,180,90,180,0,180,180,0];
+		//藥水種類名稱
+		this.potionType=['藥水','飛濺藥水'];
+		//藥水等級名稱還有延長版名稱
+		this.potionAttributeName = ['I','II','(延長版)'];
+	}
+	//協助計算藥水值的物件
+	function potionHelper( potionArray ){
+		var potionData=potionArray;
+		//取得藥水效果的id值
+		this.getEffectID=function(value){
+			return value&15;
+		}
+		//得取得藥水的效果名稱
+		this.getEffectName = function (value){
+			return potionData.potionName[this.getEffectID(value)];
+		}
+		//是否為延長版藥水是的話為1，反之則0
+		this.isExtendPotion = function (value) {
+			return (value&64)==64?1:0;
+		}
+		//取得效果時長，若為即刻生效藥水則為0
+		this.getEffectTime = function (value){
+			return potionData.potionEffectTime[this.getEffectID(value)];
+		}
+		//取得藥水等級,若為時效性藥水則為0(0為1級，1為2級
+		this.getPotionLevel = function (value){
+			return ((value&32)==32?1:0)&(~(potionData.potionAttribute[this.getEffectID(value)]));
+		}
+		//取得藥水種類，一般藥水為0，噴濺藥水為1
+		this.getType = function (value){
+			return (value&16384)==16384?1:0;
+		}
+		//取得藥水文字色碼,回傳字串
+		this.getColor = function (value){
+			return potionData.potionColor[this.getEffectID(value)];
+		}
+		//取得藥水正確的名稱
+		this.getPotionName = function (value){
+			var typeName = potionData.potionType[this.getType(value)];
+			var effectName = this.getEffectName(value);
+			if(effectName == ''){
+				switch(value&8304){
+					case 0:
+						return potionData.potionNarmalExtName[0];
+						break;
+					case 16:
+						return potionData.potionNarmalExtName[1]+typeName;
+						break;
+					case 32:
+						return potionData.potionNarmalExtName[2]+typeName;
+						break;
+					case 64:
+						return potionData.potionNarmalExtName[3]+typeName;
+						break;
+					case 8192:
+						return potionData.potionNarmalExtName[4]+typeName;
+						break;
+					default :
+						return potionData.potionNarmalExtName[5]+typeName;
+						
+				}
+			}else{
+				var effectTime = this.getEffectTime(value)*(this.isExtendPotion(value)?8:3)/3;
+				var effectTime = effectTime*(this.getType(value)?3:4)/4;
+				var effectTime = effectTime*(this.getPotionLevel(value)?1:2)/2;
+				var effectTimeString =  Math.floor(effectTime/60) + ':' + (effectTime%60>9?'':'0')+Math.floor(effectTime%60);
+				var effectLevel = this.getPotionLevel(value);
+				var color = this.getColor(value);
+				return color+(this.isExtendPotion(value)?potionData.potionAttributeName[2]:'')+effectName+potionData.potionAttributeName[effectLevel]+typeName+'('+effectTimeString+')';
+			}
+		}
+	}
+	
+	var ph = new potionHelper(potionArray);
+	return ph.getPotionName(v);
+}",
+"Items>>>1>>>Damage":"function p(v){
+	//儲存所有藥水的資料
+	var potionArray=new function (){
+		//藥水的名稱
+		this.potionName=['','回覆','迅捷','抗火','劇毒','治療','夜視','清澈(不可能出現)','虛弱','力量','緩速','跳耀','傷害','水下呼吸','隱身','稀薄(不可能出現)'];
+		this.potionNarmalExtName=['水瓶','粗製的','混濁的','(延長版)平凡的','平凡的','<錯誤>'];
+		//藥水文字的顏色預設空字串
+		this.potionColor=['','','','','','','','','','','','','','','',''];
+		//藥水的種類，0為預設或是時效性藥水，1為時效性藥水(無藥水等級)
+		this.potionAttribute=[0,0,0,1,0,0,1,0,1,0,1,0,0,1,1,0];
+		//藥效的時長，若為藥效性藥水(立即治療)則值為0，單位為秒
+		this.potionEffectTime=[0,45,180,180,45,0,180,0,90,180,90,180,0,180,180,0];
+		//藥水種類名稱
+		this.potionType=['藥水','飛濺藥水'];
+		//藥水等級名稱還有延長版名稱
+		this.potionAttributeName = ['I','II','(延長版)'];
+	}
+	//協助計算藥水值的物件
+	function potionHelper( potionArray ){
+		var potionData=potionArray;
+		//取得藥水效果的id值
+		this.getEffectID=function(value){
+			return value&15;
+		}
+		//得取得藥水的效果名稱
+		this.getEffectName = function (value){
+			return potionData.potionName[this.getEffectID(value)];
+		}
+		//是否為延長版藥水是的話為1，反之則0
+		this.isExtendPotion = function (value) {
+			return (value&64)==64?1:0;
+		}
+		//取得效果時長，若為即刻生效藥水則為0
+		this.getEffectTime = function (value){
+			return potionData.potionEffectTime[this.getEffectID(value)];
+		}
+		//取得藥水等級,若為時效性藥水則為0(0為1級，1為2級
+		this.getPotionLevel = function (value){
+			return ((value&32)==32?1:0)&(~(potionData.potionAttribute[this.getEffectID(value)]));
+		}
+		//取得藥水種類，一般藥水為0，噴濺藥水為1
+		this.getType = function (value){
+			return (value&16384)==16384?1:0;
+		}
+		//取得藥水文字色碼,回傳字串
+		this.getColor = function (value){
+			return potionData.potionColor[this.getEffectID(value)];
+		}
+		//取得藥水正確的名稱
+		this.getPotionName = function (value){
+			var typeName = potionData.potionType[this.getType(value)];
+			var effectName = this.getEffectName(value);
+			if(effectName == ''){
+				switch(value&8304){
+					case 0:
+						return potionData.potionNarmalExtName[0];
+						break;
+					case 16:
+						return potionData.potionNarmalExtName[1]+typeName;
+						break;
+					case 32:
+						return potionData.potionNarmalExtName[2]+typeName;
+						break;
+					case 64:
+						return potionData.potionNarmalExtName[3]+typeName;
+						break;
+					case 8192:
+						return potionData.potionNarmalExtName[4]+typeName;
+						break;
+					default :
+						return potionData.potionNarmalExtName[5]+typeName;
+						
+				}
+			}else{
+				var effectTime = this.getEffectTime(value)*(this.isExtendPotion(value)?8:3)/3;
+				var effectTime = effectTime*(this.getType(value)?3:4)/4;
+				var effectTime = effectTime*(this.getPotionLevel(value)?1:2)/2;
+				var effectTimeString =  Math.floor(effectTime/60) + ':' + (effectTime%60>9?'':'0')+Math.floor(effectTime%60);
+				var effectLevel = this.getPotionLevel(value);
+				var color = this.getColor(value);
+				return color+(this.isExtendPotion(value)?potionData.potionAttributeName[2]:'')+effectName+potionData.potionAttributeName[effectLevel]+typeName+'('+effectTimeString+')';
+			}
+		}
+	}
+	
+	var ph = new potionHelper(potionArray);
+	return ph.getPotionName(v);
+}",
+"Items>>>2>>>Damage":"function p(v){
+	//儲存所有藥水的資料
+	var potionArray=new function (){
+		//藥水的名稱
+		this.potionName=['','回覆','迅捷','抗火','劇毒','治療','夜視','清澈(不可能出現)','虛弱','力量','緩速','跳耀','傷害','水下呼吸','隱身','稀薄(不可能出現)'];
+		this.potionNarmalExtName=['水瓶','粗製的','混濁的','(延長版)平凡的','平凡的','<錯誤>'];
+		//藥水文字的顏色代碼,預設空字串
+		this.potionColor=['','','','','','','','','','','','','','','',''];
+		//藥水的種類，0為預設或是時效性藥水，1為時效性藥水(無藥水等級)
+		this.potionAttribute=[0,0,0,1,0,0,1,0,1,0,1,0,0,1,1,0];
+		//藥效的時長，若為藥效性藥水(立即治療)則值為0，單位為秒
+		this.potionEffectTime=[0,45,180,180,45,0,180,0,90,180,90,180,0,180,180,0];
+		//藥水種類名稱
+		this.potionType=['藥水','飛濺藥水'];
+		//藥水等級名稱還有延長版名稱
+		this.potionAttributeName = ['I','II','(延長版)'];
+	}
+	//協助計算藥水值的物件
+	function potionHelper( potionArray ){
+		var potionData=potionArray;
+		//取得藥水效果的id值
+		this.getEffectID=function(value){
+			return value&15;
+		}
+		//得取得藥水的效果名稱
+		this.getEffectName = function (value){
+			return potionData.potionName[this.getEffectID(value)];
+		}
+		//是否為延長版藥水是的話為1，反之則0
+		this.isExtendPotion = function (value) {
+			return (value&64)==64?1:0;
+		}
+		//取得效果時長，若為即刻生效藥水則為0
+		this.getEffectTime = function (value){
+			return potionData.potionEffectTime[this.getEffectID(value)];
+		}
+		//取得藥水等級,若為時效性藥水則為0(0為1級，1為2級
+		this.getPotionLevel = function (value){
+			return ((value&32)==32?1:0)&(~(potionData.potionAttribute[this.getEffectID(value)]));
+		}
+		//取得藥水種類，一般藥水為0，噴濺藥水為1
+		this.getType = function (value){
+			return (value&16384)==16384?1:0;
+		}
+		//取得藥水文字色碼,回傳字串
+		this.getColor = function (value){
+			return potionData.potionColor[this.getEffectID(value)];
+		}
+		//取得藥水正確的名稱
+		this.getPotionName = function (value){
+			var typeName = potionData.potionType[this.getType(value)];
+			var effectName = this.getEffectName(value);
+			if(effectName == ''){
+				switch(value&8304){
+					case 0:
+						return potionData.potionNarmalExtName[0];
+						break;
+					case 16:
+						return potionData.potionNarmalExtName[1]+typeName;
+						break;
+					case 32:
+						return potionData.potionNarmalExtName[2]+typeName;
+						break;
+					case 64:
+						return potionData.potionNarmalExtName[3]+typeName;
+						break;
+					case 8192:
+						return potionData.potionNarmalExtName[4]+typeName;
+						break;
+					default :
+						return potionData.potionNarmalExtName[5]+typeName;
+						
+				}
+			}else{
+				var effectTime = this.getEffectTime(value)*(this.isExtendPotion(value)?8:3)/3;
+				var effectTime = effectTime*(this.getType(value)?3:4)/4;
+				var effectTime = effectTime*(this.getPotionLevel(value)?1:2)/2;
+				var effectTimeString =  Math.floor(effectTime/60) + ':' + (effectTime%60>9?'':'0')+Math.floor(effectTime%60);
+				var effectLevel = this.getPotionLevel(value);
+				var color = this.getColor(value);
+				return color+(this.isExtendPotion(value)?potionData.potionAttributeName[2]:'')+effectName+potionData.potionAttributeName[effectLevel]+typeName+'('+effectTimeString+')';
+			}
+		}
+	}
+	
+	var ph = new potionHelper(potionArray);
+	return ph.getPotionName(v);
+}"
+		}		
+	},
+	"tooltip" : {
+		"minecraft:skull" : {
+			"SkullOwner" : "擁有者"
+		}
+	}
+}


### PR DESCRIPTION
新增對所有有age tag的實體顯示交配剩餘時間,所為幼體則顯示成長剩餘時間
新增對釀造台3個欄位的藥水的辨識,從damage算出藥水種類
顯示頭顱方塊的擁有者,還有物品頭顱的擁有者
ps.作者,能不能讓未來版本可以一次指定多個nbt並且傳入string format或是以陣列傳入javascript來達到更進階的功能~^w^這個模組太棒了~如果可以傳入自訂的js庫並且供呼叫函數(像names[]那樣從哪裡都可以存取到)就可以大量減少重複的代碼~
